### PR TITLE
Create transparent_background.css

### DIFF
--- a/themes/transparent_background.css
+++ b/themes/transparent_background.css
@@ -1,0 +1,43 @@
+
+.cm-tabcolor-row {
+
+}
+.cm-tabcolor-header {
+	font-weight: bolder;
+}
+.cm-tabcolor-col1 {
+	background-color: rgba(14, 110, 253, 0.1) !important;
+	color: #212529 !important;
+}
+.cm-tabcolor-col2 {
+	background-color: rgba(255, 193, 8, 0.1) !important;
+	color: #212529 !important;
+}
+.cm-tabcolor-col3 {
+	background-color: rgba(220, 53, 69, 0.1) !important;
+	color: #212529 !important;
+}
+.cm-tabcolor-col4 {
+	background-color: rgba(13, 202, 240, 0.1) !important;
+	color: #212529 !important;
+}
+.cm-tabcolor-col5 {
+	background-color: rgba(25, 135, 84, 0.1) !important;
+	color: #212529 !important;
+}
+.cm-tabcolor-col6 {
+	background-color: rgba(112, 133, 153, 0.1) !important;
+	color: #212529 !important;
+}
+.cm-tabcolor-col7 {
+	background-color: rgba(14, 110, 253, 0.1) !important;
+	color: #212529 !important;
+}
+.cm-tabcolor-col8 {
+	background-color: rgba(255, 193, 8, 0.1) !important;
+	color: #212529 !important;
+}
+.cm-tabcolor-col9 {
+	background-color: rgba(220, 53, 69, 0.1) !important;
+	color: #212529 !important;
+}


### PR DESCRIPTION
Added a transparent background theme that does not require changing the text color and is easier on the eyes.

![Screenshot_20211102_200821](https://user-images.githubusercontent.com/3527534/139921308-5c626c4e-981b-4f42-bb02-70e97acdc462.png)

I've kept the original colors, though I had to change column 6, since transparent almost white... is not very visible.
I'd also change the green (column 5) a bit, since it's very close to the grey of column 6.